### PR TITLE
Automatic update of NUnit to 3.12.0

### DIFF
--- a/src/Tests/Monitorify.Core.Tests.Unit/Monitorify.Core.Tests.Unit.csproj
+++ b/src/Tests/Monitorify.Core.Tests.Unit/Monitorify.Core.Tests.Unit.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Moq" Version="4.7.99" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">

--- a/src/Tests/Monitorify.Publisher.Email.Tests.Integration/Monitorify.Publisher.Email.Tests.Integration.csproj
+++ b/src/Tests/Monitorify.Publisher.Email.Tests.Integration/Monitorify.Publisher.Email.Tests.Integration.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">

--- a/src/Tests/Monitorify.Publisher.Tests.Unit/Monitorify.Publisher.Tests.Unit.csproj
+++ b/src/Tests/Monitorify.Publisher.Tests.Unit/Monitorify.Publisher.Tests.Unit.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Moq" Version="4.7.99" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">


### PR DESCRIPTION
NuKeeper has generated a minor update of `NUnit` to `3.12.0` from `3.8.1`
`NUnit 3.12.0` was published at `2019-05-15T00:24:28Z`, 6 months ago

3 project updates:
Updated `src\Tests\Monitorify.Core.Tests.Unit\Monitorify.Core.Tests.Unit.csproj` to `NUnit` `3.12.0` from `3.8.1`
Updated `src\Tests\Monitorify.Publisher.Email.Tests.Integration\Monitorify.Publisher.Email.Tests.Integration.csproj` to `NUnit` `3.12.0` from `3.8.1`
Updated `src\Tests\Monitorify.Publisher.Tests.Unit\Monitorify.Publisher.Tests.Unit.csproj` to `NUnit` `3.12.0` from `3.8.1`

[NUnit 3.12.0 on NuGet.org](https://www.nuget.org/packages/NUnit/3.12.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
