### PR TITLE
Automatic update of NUnit3TestAdapter to 3.15.1

### DIFF
--- a/src/Tests/Monitorify.Core.Tests.Unit/Monitorify.Core.Tests.Unit.csproj
+++ b/src/Tests/Monitorify.Core.Tests.Unit/Monitorify.Core.Tests.Unit.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0-*" />

--- a/src/Tests/Monitorify.Publisher.Email.Tests.Integration/Monitorify.Publisher.Email.Tests.Integration.csproj
+++ b/src/Tests/Monitorify.Publisher.Email.Tests.Integration/Monitorify.Publisher.Email.Tests.Integration.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0-*" />

--- a/src/Tests/Monitorify.Publisher.Tests.Unit/Monitorify.Publisher.Tests.Unit.csproj
+++ b/src/Tests/Monitorify.Publisher.Tests.Unit/Monitorify.Publisher.Tests.Unit.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0-*" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `NUnit3TestAdapter` to `3.15.1` from `3.8.0`
`NUnit3TestAdapter 3.15.1` was published at `2019-08-30T12:18:40Z`, 3 months ago

3 project updates:
Updated `src\Tests\Monitorify.Core.Tests.Unit\Monitorify.Core.Tests.Unit.csproj` to `NUnit3TestAdapter` `3.15.1` from `3.8.0`
Updated `src\Tests\Monitorify.Publisher.Email.Tests.Integration\Monitorify.Publisher.Email.Tests.Integration.csproj` to `NUnit3TestAdapter` `3.15.1` from `3.8.0`
Updated `src\Tests\Monitorify.Publisher.Tests.Unit\Monitorify.Publisher.Tests.Unit.csproj` to `NUnit3TestAdapter` `3.15.1` from `3.8.0`

[NUnit3TestAdapter 3.15.1 on NuGet.org](https://www.nuget.org/packages/NUnit3TestAdapter/3.15.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
