### PR TITLE
Automatic update of Newtonsoft.Json to 12.0.3

### DIFF
--- a/src/Monitorify.Core/Monitorify.Core.csproj
+++ b/src/Monitorify.Core/Monitorify.Core.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a major update of `Newtonsoft.Json` to `12.0.3` from `10.0.3`
`Newtonsoft.Json 12.0.3` was published at `2019-11-09T01:27:30Z`, 20 days ago

1 project update:
Updated `src\Monitorify.Core\Monitorify.Core.csproj` to `Newtonsoft.Json` `12.0.3` from `10.0.3`

[Newtonsoft.Json 12.0.3 on NuGet.org](https://www.nuget.org/packages/Newtonsoft.Json/12.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
