### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 16.4.0

### DIFF
--- a/src/Tests/Monitorify.Core.Tests.Unit/Monitorify.Core.Tests.Unit.csproj
+++ b/src/Tests/Monitorify.Core.Tests.Unit/Monitorify.Core.Tests.Unit.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\..\Monitorify.Core\Monitorify.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />

--- a/src/Tests/Monitorify.Publisher.Email.Tests.Integration/Monitorify.Publisher.Email.Tests.Integration.csproj
+++ b/src/Tests/Monitorify.Publisher.Email.Tests.Integration/Monitorify.Publisher.Email.Tests.Integration.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
   </ItemGroup>

--- a/src/Tests/Monitorify.Publisher.Tests.Unit/Monitorify.Publisher.Tests.Unit.csproj
+++ b/src/Tests/Monitorify.Publisher.Tests.Unit/Monitorify.Publisher.Tests.Unit.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\..\Monitorify.Publisher\Monitorify.Publisher.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.NET.Test.Sdk` to `16.4.0` from `15.3.0`
`Microsoft.NET.Test.Sdk 16.4.0` was published at `2019-11-06T10:50:48Z`, 23 days ago

3 project updates:
Updated `src\Tests\Monitorify.Core.Tests.Unit\Monitorify.Core.Tests.Unit.csproj` to `Microsoft.NET.Test.Sdk` `16.4.0` from `15.3.0`
Updated `src\Tests\Monitorify.Publisher.Email.Tests.Integration\Monitorify.Publisher.Email.Tests.Integration.csproj` to `Microsoft.NET.Test.Sdk` `16.4.0` from `15.3.0`
Updated `src\Tests\Monitorify.Publisher.Tests.Unit\Monitorify.Publisher.Tests.Unit.csproj` to `Microsoft.NET.Test.Sdk` `16.4.0` from `15.3.0`

[Microsoft.NET.Test.Sdk 16.4.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.4.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
