### PR TITLE
Automatic update of Microsoft.Extensions.Configuration to 3.0.1

### DIFF
--- a/src/Examples/Monitorify.EmailPublisher.Console/Monitorify.EmailPublisher.Console.csproj
+++ b/src/Examples/Monitorify.EmailPublisher.Console/Monitorify.EmailPublisher.Console.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\Monitorify.Publisher.Email\Monitorify.Publisher.Email.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Monitorify.Publisher.Email.Tests.Integration/Monitorify.Publisher.Email.Tests.Integration.csproj
+++ b/src/Tests/Monitorify.Publisher.Email.Tests.Integration/Monitorify.Publisher.Email.Tests.Integration.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\..\Monitorify.Publisher.Email\Monitorify.Publisher.Email.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.8.1" />


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.Extensions.Configuration` to `3.0.1` from `2.0.0`
`Microsoft.Extensions.Configuration 3.0.1` was published at `2019-11-18T23:13:54Z`, 10 days ago

2 project updates:
Updated `src\Examples\Monitorify.EmailPublisher.Console\Monitorify.EmailPublisher.Console.csproj` to `Microsoft.Extensions.Configuration` `3.0.1` from `2.0.0`
Updated `src\Tests\Monitorify.Publisher.Email.Tests.Integration\Monitorify.Publisher.Email.Tests.Integration.csproj` to `Microsoft.Extensions.Configuration` `3.0.1` from `2.0.0`

[Microsoft.Extensions.Configuration 3.0.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Configuration/3.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
